### PR TITLE
PV move ordering

### DIFF
--- a/src/movesort.cpp
+++ b/src/movesort.cpp
@@ -5,16 +5,20 @@
 
 namespace sonic {
 
-void sort_moves(const Position& pos, MoveList& movelist) {
+void sort_moves(const Position& pos, MoveList& movelist, Move follow_pv_move) {
     auto move_score = [&](Move m) -> int {
-        // 1. Promotions
+        // 1. PV move
+        if(m == follow_pv_move) {
+            return 1000000;
+        }
+        // 2. Promotions
         if(m.promotion() == Move::Promotion::Queen) {
             return 100001;
         }
         if(m.promotion() == Move::Promotion::Knight) {
             return 100000;
         }
-        // 2. MVV-LVA
+        // 3. MVV-LVA
         // Pawn, Knight, Bishop, Rook, Queen, King
         static constexpr int AttackValues[6] = {50, 30, 30, 20, 10, 0};
         Piece from = pos.piece_on(m.from());
@@ -22,7 +26,7 @@ void sort_moves(const Position& pos, MoveList& movelist) {
         if(pos.is_capture(m)) {
             return AttackValues[type(from)] - AttackValues[type(to)] + 500;
         }
-        // 3. Others
+        // 4. Others
         return -AttackValues[type(from)];
     };
     static int scores[218];

--- a/src/movesort.h
+++ b/src/movesort.h
@@ -4,6 +4,6 @@
 
 namespace sonic {
 
-void sort_moves(const Position& pos, MoveList& movelist);
+void sort_moves(const Position& pos, MoveList& movelist, Move follow_pv_move);
 
 } // namespace sonic

--- a/src/search.h
+++ b/src/search.h
@@ -36,8 +36,9 @@ struct SearchInfo {
 
     std::array<std::uint64_t, MAX_DEPTH> history_keys;
 
-    std::array<std::array<Move, MAX_DEPTH>, MAX_DEPTH> pv;
+    std::array<std::array<Move, MAX_DEPTH>, MAX_DEPTH> pv = {};
     std::array<int, MAX_DEPTH> pv_length = {};
+    bool follow_pv = false;
 
     void insert_pv(int ply, Move move) {
         pv[ply][0] = move;


### PR DESCRIPTION
```
Elo   | 81.72 +- 21.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 840 W: 444 L: 250 D: 146
Penta | [32, 47, 152, 73, 116]
https://felixhuang07.pythonanywhere.com/test/35/
```
Bench: 16472823