### PR TITLE
Late move reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -146,7 +146,7 @@ Value negamax(Position& pos, SearchInfo& search_info, Value alpha, Value beta, i
     Value best_score = -VALUE_INF;
     Move best_move = MOVE_NONE;
     TTFlag flag = TTFlag::TT_ALPHA;
-    int legal_moves = 0;
+    int moves_searched = 0;
     for(Move m : movelist) {
         bool is_quiet = pos.is_quiet(m);
         UndoInfo info;
@@ -156,7 +156,7 @@ Value negamax(Position& pos, SearchInfo& search_info, Value alpha, Value beta, i
             search_info.depth--;
             continue;
         }
-        legal_moves++;
+        moves_searched++;
         bool gives_check = pos.in_check();
         if(!root_node) {
             // Futility pruning.
@@ -168,10 +168,19 @@ Value negamax(Position& pos, SearchInfo& search_info, Value alpha, Value beta, i
             }
         }
         prefetch(TT.entry_address(pos.hashkey()));
-        // PV search.
-        Value score = -negamax(pos, search_info, -alpha - 1, -alpha, depth - 1, true);
-        if(alpha < score && score < beta) {
-            score = -negamax(pos, search_info, -beta, -alpha, depth - 1, true);
+        Value score = VALUE_NONE;
+        if(moves_searched >= 5 && depth >= 3 && !in_check) {
+            score = -negamax(pos, search_info, -alpha - 1, -alpha, depth - 2, true);
+        } else {
+            // Do search on full-depth.
+            score = VALUE_INF;
+        }
+        if(score > alpha) {
+            // PV search.
+            score = -negamax(pos, search_info, -alpha - 1, -alpha, depth - 1, true);
+            if(alpha < score && score < beta) {
+                score = -negamax(pos, search_info, -beta, -alpha, depth - 1, true);
+            }
         }
         pos.unmake_move(info);
         search_info.depth--;
@@ -189,7 +198,7 @@ Value negamax(Position& pos, SearchInfo& search_info, Value alpha, Value beta, i
             }
         }
     }
-    if(legal_moves == 0) {
+    if(moves_searched == 0) {
         // Checkmate or Stalemate.
         return in_check ? mated_in(ply) : VALUE_DRAW;
     }


### PR DESCRIPTION
```
Elo   | 13.54 +- 7.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5496 W: 2297 L: 2083 D: 1116
Penta | [357, 429, 1052, 463, 447]
https://felixhuang07.pythonanywhere.com/test/32/
```
Bench: 5856647