### PR TITLE
TT move ordering

### DIFF
--- a/src/movesort.cpp
+++ b/src/movesort.cpp
@@ -5,10 +5,10 @@
 
 namespace sonic {
 
-void sort_moves(const Position& pos, MoveList& movelist, Move follow_pv_move) {
+void sort_moves(const Position& pos, MoveList& movelist, Move tt_move) {
     auto move_score = [&](Move m) -> int {
-        // 1. PV move
-        if(m == follow_pv_move) {
+        // 1. TT move
+        if(m == tt_move) {
             return 1000000;
         }
         // 2. Promotions

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -148,11 +148,8 @@ Value negamax(Position& pos, SearchInfo& search_info, Value alpha, Value beta, i
 
     MoveList movelist;
     generate_moves<GenType::ALL>(pos, movelist);
-    Move follow_pv_move = (search_info.follow_pv ? search_info.pv[ply][0] : MOVE_NONE);
-    sort_moves(pos, movelist, follow_pv_move);
-    if(!movelist.empty() && movelist[0] == follow_pv_move) {
-        search_info.follow_pv = true;
-    }
+    sort_moves(pos, movelist, tt_move);
+
     Value best_score = -VALUE_INF;
     Move best_move = MOVE_NONE;
     TTFlag flag = TTFlag::TT_ALPHA;


### PR DESCRIPTION
```
Elo   | 95.94 +- 22.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 724 W: 382 L: 187 D: 155
Penta | [22, 38, 120, 87, 95]
https://felixhuang07.pythonanywhere.com/test/53/
```
Bench: 4153577